### PR TITLE
Fix broken URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For the 'version' column, servers have "(each PR)" if their continuous integrati
 
 ### Footnotes
 
-1) for some servers we have manually tested that they include a working webid-oidc identity provider, but we don't have the headless-browser tests that confirm this automatically for these servers. The [solid-oidc IDP tester page](https://inrupt.github.io/solid-oidc-tests/), in contrast, requires human interaction, but with that it can test any publicly hosted IDP.
+1) for some servers we have manually tested that they include a working webid-oidc identity provider, but we don't have the headless-browser tests that confirm this automatically for these servers. The [solid-oidc IDP tester page](https://solid-contrib.github.io/solid-oidc-tests/), in contrast, requires human interaction, but with that it can test any publicly hosted IDP.
 
 2) TrinPod [will support](https://gitter.im/solid/test-suite?at=612101ace8de9946b4324a0b) this in the future
 


### PR DESCRIPTION
The Solid Authentication Test no longer lives under `inrupt.github.io`, so the link was broken.

As a side-note, I think the link to `https://github.com/solid-contrib/solidservers.org/edit/list-pod-hosters/README.md` is also broken (gives a 404) but I am not sure what it should link to.